### PR TITLE
feat: audit and refresh for Rust 1.95 through 1.97

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   checks:
-    name: Validate & compile-check
+    name: Validate, test & compile-check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      # Toolchain/target are pinned by checks/rust-toolchain.toml (Rust 1.95.0).
-      - uses: dtolnay/rust-toolchain@1.95.0
+      # Toolchain/target are pinned by checks/rust-toolchain.toml (Rust 1.97.1).
+      - uses: dtolnay/rust-toolchain@1.97.1
         with:
           targets: x86_64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this skill are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 semantic versioning for the rule set.
 
+## [Unreleased]
+
+### Added
+- `lint-warnings-deny-config`: prefer Cargo `[build] warnings = "deny"` for rustc
+  CI instead of a global `RUSTFLAGS=-Dwarnings`.
+- `num-bit-width`: use the Rust 1.97 integer bit-manipulation APIs
+  (`bit_width`, `highest_one`/`lowest_one`, `isolate_*_one`) instead of
+  hand-rolled shift and mask loops.
+
+### Changed
+- Refreshed for Rust 1.97: pinned the compile-check toolchain and CI to 1.97.1
+  and updated "Current for Rust" claims.
+- Fixed `unsafe-no-mangle-unsafe` for Rust 1.97 `link_section` validation
+  (ELF `.init_array` is now an error on Mach-O).
+
+Now 267 rules across 26 categories.
+
 ## [1.5.1]
 
 ### Changed
@@ -81,6 +98,7 @@ Now 218 rules across 18 categories.
 ### Added
 - Initial release: 179 rules across 14 categories.
 
+[Unreleased]: https://github.com/leonardomso/rust-skills
 [1.5.0]: https://github.com/leonardomso/rust-skills
 [1.4.0]: https://github.com/leonardomso/rust-skills
 [1.3.0]: https://github.com/leonardomso/rust-skills

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,28 @@ semantic versioning for the rule set.
 - `num-bit-width`: use the Rust 1.97 integer bit-manipulation APIs
   (`bit_width`, `highest_one`/`lowest_one`, `isolate_*_one`) instead of
   hand-rolled shift and mask loops.
+- `pat-if-let-guards`: bind fallible match-arm data with Rust 1.95 `if let`
+  guards instead of parsing twice or unwrapping.
+- `conc-atomic-update`: use Rust 1.95 atomic `update` / `try_update` instead of
+  hand-written compare-exchange retry loops.
+- `proj-cfg-select`: make one-of-many conditional compilation explicit with
+  Rust 1.95 `cfg_select!`.
+- `trait-ord-consistent`: keep equality and ordering contracts aligned so
+  ordered collections remain correct.
 
 ### Changed
-- Refreshed for Rust 1.97: pinned the compile-check toolchain and CI to 1.97.1
-  and updated "Current for Rust" claims.
-- Fixed `unsafe-no-mangle-unsafe` for Rust 1.97 `link_section` validation
-  (ELF `.init_array` is now an error on Mach-O).
+- Audited Rust 1.95 through 1.97 release changes, pinned the compile-check
+  toolchain and CI to 1.97.1, and updated "Current for Rust" claims.
+- Updated existing conversion, `NonZero`, workspace dependency, enum layout,
+  collection insertion, visibility linting, read-only lockfile, pattern, cfg,
+  atomic, and unsafe/FFI guidance for useful 1.95–1.97 changes and
+  compatibility notes.
+- Added executable release-behavior checks for the new language/library
+  guidance; generated examples remain compile-checked against the baseline.
+- Fixed `unsafe-no-mangle-unsafe` for Rust 1.97 `link_section` validation (ELF
+  `.init_array` is now an error on Mach-O).
 
-Now 267 rules across 26 categories.
+Now 271 rules across 26 categories.
 
 ## [1.5.1]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Run the same checks CI runs:
 python3 checks/validate.py
 python3 checks/gen_index.py --check
 
-# compile-check the examples (Rust >= 1.95)
+# compile-check the examples (Rust >= 1.97)
 cd checks
 python3 gen.py
 cargo check --examples --keep-going --message-format=json > check.json

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Rust Skills
 
-![rules](https://img.shields.io/badge/rules-267-blue)
+![rules](https://img.shields.io/badge/rules-271-blue)
 ![categories](https://img.shields.io/badge/categories-26-blue)
 ![Rust](https://img.shields.io/badge/Rust-1.97%20%2F%202024%20edition-orange)
 ![license](https://img.shields.io/badge/license-MIT-green)
 
-267 Rust rules your AI coding agent can use to write better code. Current for Rust 1.97 (2024 edition).
+271 Rust rules your AI coding agent can use to write better code. Current for Rust 1.97 (2024 edition).
 
 Works with Claude Code, Cursor, Windsurf, Copilot, Codex, Aider, Zed, Amp, Cline, and pretty much any other agent that supports skills.
 
@@ -66,7 +66,7 @@ fn first_word(s: &str) -> Option<&str> {
 
 ## What's in here
 
-267 rules split into 26 categories:
+271 rules split into 26 categories:
 
 | Category | Rules | What it covers |
 |----------|-------|----------------|

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Rust Skills
 
-![rules](https://img.shields.io/badge/rules-265-blue)
+![rules](https://img.shields.io/badge/rules-267-blue)
 ![categories](https://img.shields.io/badge/categories-26-blue)
-![Rust](https://img.shields.io/badge/Rust-1.96%20%2F%202024%20edition-orange)
+![Rust](https://img.shields.io/badge/Rust-1.97%20%2F%202024%20edition-orange)
 ![license](https://img.shields.io/badge/license-MIT-green)
 
-265 Rust rules your AI coding agent can use to write better code. Current for Rust 1.96 (2024 edition).
+267 Rust rules your AI coding agent can use to write better code. Current for Rust 1.97 (2024 edition).
 
 Works with Claude Code, Cursor, Windsurf, Copilot, Codex, Aider, Zed, Amp, Cline, and pretty much any other agent that supports skills.
 
@@ -66,7 +66,7 @@ fn first_word(s: &str) -> Option<&str> {
 
 ## What's in here
 
-265 rules split into 26 categories:
+267 rules split into 26 categories:
 
 | Category | Rules | What it covers |
 |----------|-------|----------------|

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: rust-skills
 description: >
-  Comprehensive Rust coding guidelines with 265 rules across 26 categories.
+  Comprehensive Rust coding guidelines with 267 rules across 26 categories.
   Use when writing, reviewing, or refactoring Rust code. Covers ownership,
   error handling, async patterns, concurrency, unsafe code, API design, memory
   optimization, performance, numeric safety, conversions, serde, pattern
@@ -21,7 +21,7 @@ metadata:
 
 # Rust Best Practices
 
-Comprehensive guide for writing high-quality, idiomatic, and highly optimized Rust code. Contains 265 rules across 26 categories, prioritized by impact to guide LLMs in code generation and refactoring. Current for Rust 1.96 (2024 edition).
+Comprehensive guide for writing high-quality, idiomatic, and highly optimized Rust code. Contains 267 rules across 26 categories, prioritized by impact to guide LLMs in code generation and refactoring. Current for Rust 1.97 (2024 edition).
 
 ## When to Apply
 
@@ -47,7 +47,7 @@ Reference these guidelines when:
 | 6 | Async/Await | HIGH | `async-` | 18 |
 | 7 | Concurrency | HIGH | `conc-` | 4 |
 | 8 | Compiler Optimization | HIGH | `opt-` | 12 |
-| 9 | Numeric & Arithmetic Safety | HIGH | `num-` | 5 |
+| 9 | Numeric & Arithmetic Safety | HIGH | `num-` | 6 |
 | 10 | Type Safety | MEDIUM | `type-` | 13 |
 | 11 | Trait & Generics Design | MEDIUM | `trait-` | 6 |
 | 12 | Conversions | MEDIUM | `conv-` | 3 |
@@ -63,7 +63,7 @@ Reference these guidelines when:
 | 22 | Observability | MEDIUM | `obs-` | 7 |
 | 23 | Performance Patterns | MEDIUM | `perf-` | 13 |
 | 24 | Project Structure | LOW | `proj-` | 14 |
-| 25 | Clippy & Linting | LOW | `lint-` | 13 |
+| 25 | Clippy & Linting | LOW | `lint-` | 14 |
 | 26 | Anti-patterns | REFERENCE | `anti-` | 15 |
 
 ---
@@ -200,6 +200,7 @@ Reference these guidelines when:
 - [`num-float-compare`](rules/num-float-compare.md) - Don't compare floats with `==`; use a tolerance, and `total_cmp` for ordering
 - [`num-saturating-clamp`](rules/num-saturating-clamp.md) - Bound values with `clamp` and saturating arithmetic
 - [`num-nonzero`](rules/num-nonzero.md) - Use `NonZero*` types to forbid zero and unlock the niche optimization
+- [`num-bit-width`](rules/num-bit-width.md) - Use integer `bit_width` / `highest_one` / `isolate_*_one` instead of hand-rolled bit math
 
 ### 10. Type Safety (MEDIUM)
 
@@ -394,6 +395,7 @@ Reference these guidelines when:
 - [`lint-workspace-lints`](rules/lint-workspace-lints.md) - Configure lints at workspace level for consistent enforcement
 - [`lint-cfg-check`](rules/lint-cfg-check.md) - Enable `unexpected_cfgs` and declare known cfgs to catch feature-gate typos
 - [`lint-clippy-nursery-selected`](rules/lint-clippy-nursery-selected.md) - Enable high-value `clippy::nursery` lints selectively, not the whole group
+- [`lint-warnings-deny-config`](rules/lint-warnings-deny-config.md) - Prefer Cargo `[build] warnings = "deny"` over `RUSTFLAGS=-Dwarnings` for rustc CI
 
 ### 26. Anti-patterns (REFERENCE)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: rust-skills
 description: >
-  Comprehensive Rust coding guidelines with 267 rules across 26 categories.
+  Comprehensive Rust coding guidelines with 271 rules across 26 categories.
   Use when writing, reviewing, or refactoring Rust code. Covers ownership,
   error handling, async patterns, concurrency, unsafe code, API design, memory
   optimization, performance, numeric safety, conversions, serde, pattern
@@ -21,7 +21,7 @@ metadata:
 
 # Rust Best Practices
 
-Comprehensive guide for writing high-quality, idiomatic, and highly optimized Rust code. Contains 267 rules across 26 categories, prioritized by impact to guide LLMs in code generation and refactoring. Current for Rust 1.97 (2024 edition).
+Comprehensive guide for writing high-quality, idiomatic, and highly optimized Rust code. Contains 271 rules across 26 categories, prioritized by impact to guide LLMs in code generation and refactoring. Current for Rust 1.97 (2024 edition).
 
 ## When to Apply
 
@@ -45,15 +45,15 @@ Reference these guidelines when:
 | 4 | Unsafe Code | CRITICAL | `unsafe-` | 7 |
 | 5 | API Design | HIGH | `api-` | 17 |
 | 6 | Async/Await | HIGH | `async-` | 18 |
-| 7 | Concurrency | HIGH | `conc-` | 4 |
+| 7 | Concurrency | HIGH | `conc-` | 5 |
 | 8 | Compiler Optimization | HIGH | `opt-` | 12 |
 | 9 | Numeric & Arithmetic Safety | HIGH | `num-` | 6 |
 | 10 | Type Safety | MEDIUM | `type-` | 13 |
-| 11 | Trait & Generics Design | MEDIUM | `trait-` | 6 |
+| 11 | Trait & Generics Design | MEDIUM | `trait-` | 7 |
 | 12 | Conversions | MEDIUM | `conv-` | 3 |
 | 13 | Const & Compile-Time | MEDIUM | `const-` | 4 |
 | 14 | Serde | MEDIUM | `serde-` | 8 |
-| 15 | Pattern Matching | MEDIUM | `pat-` | 5 |
+| 15 | Pattern Matching | MEDIUM | `pat-` | 6 |
 | 16 | Macros | MEDIUM | `macro-` | 8 |
 | 17 | Closures | MEDIUM | `closure-` | 5 |
 | 18 | Collections | MEDIUM | `coll-` | 4 |
@@ -62,7 +62,7 @@ Reference these guidelines when:
 | 21 | Documentation | MEDIUM | `doc-` | 12 |
 | 22 | Observability | MEDIUM | `obs-` | 7 |
 | 23 | Performance Patterns | MEDIUM | `perf-` | 13 |
-| 24 | Project Structure | LOW | `proj-` | 14 |
+| 24 | Project Structure | LOW | `proj-` | 15 |
 | 25 | Clippy & Linting | LOW | `lint-` | 14 |
 | 26 | Anti-patterns | REFERENCE | `anti-` | 15 |
 
@@ -177,6 +177,7 @@ Reference these guidelines when:
 - [`conc-scoped-threads`](rules/conc-scoped-threads.md) - Use `std::thread::scope` to borrow stack data across threads
 - [`conc-atomic-ordering`](rules/conc-atomic-ordering.md) - Use the weakest correct memory `Ordering` for every atomic operation
 - [`conc-thread-local`](rules/conc-thread-local.md) - Prefer `thread_local!` with `Cell`/`RefCell` over `static mut`
+- [`conc-atomic-update`](rules/conc-atomic-update.md) - Use atomic `update` / `try_update` instead of hand-written compare-exchange loops
 
 ### 8. Compiler Optimization (HIGH)
 
@@ -226,6 +227,7 @@ Reference these guidelines when:
 - [`trait-default-methods`](rules/trait-default-methods.md) - Define a trait in terms of a few required methods plus defaulted ones built on top of them
 - [`trait-dyn-vs-generic`](rules/trait-dyn-vs-generic.md) - Choose static dispatch (generics / `impl Trait`) vs dynamic dispatch (`dyn Trait`) deliberately
 - [`trait-object-safety`](rules/trait-object-safety.md) - Keep a trait dyn-compatible (object-safe) when you need `dyn Trait`
+- [`trait-ord-consistent`](rules/trait-ord-consistent.md) - Keep `Ord`, `PartialOrd`, `Eq`, and `PartialEq` consistent
 
 ### 12. Conversions (MEDIUM)
 
@@ -258,6 +260,7 @@ Reference these guidelines when:
 - [`pat-if-let-chains`](rules/pat-if-let-chains.md) - Use `if let` chains to combine pattern bindings and conditions
 - [`pat-exhaustive-enum`](rules/pat-exhaustive-enum.md) - Match owned enums exhaustively; avoid catch-all `_` that hides new variants
 - [`pat-at-bindings`](rules/pat-at-bindings.md) - Use `@` bindings to capture a value while matching it against a pattern
+- [`pat-if-let-guards`](rules/pat-if-let-guards.md) - Use `if let` match guards to bind data needed only by one arm
 
 ### 16. Macros (MEDIUM)
 
@@ -379,6 +382,7 @@ Reference these guidelines when:
 - [`proj-feature-additive`](rules/proj-feature-additive.md) - Design Cargo features to be strictly additive
 - [`proj-msrv-declare`](rules/proj-msrv-declare.md) - Declare `rust-version` (MSRV) in Cargo.toml and test it in CI
 - [`proj-build-rs-minimal`](rules/proj-build-rs-minimal.md) - Keep `build.rs` minimal, deterministic, and idempotent
+- [`proj-cfg-select`](rules/proj-cfg-select.md) - Use `cfg_select!` for one-of-many conditional items or expressions
 
 ### 25. Clippy & Linting (LOW)
 

--- a/checks/README.md
+++ b/checks/README.md
@@ -1,8 +1,9 @@
-# checks — compile-verify the rule examples
+# checks — verify rule structure, behavior, and examples
 
 A dev tool that type-checks the ` ```rust ` code blocks in `../rules/*.md` so the
-"Good" examples we tell agents to write actually compile. Not part of the
-published skill.
+"Good" examples we tell agents to write actually compile. Focused Rust tests
+also execute release-specific behavior that compilation alone cannot prove.
+Not part of the published skill.
 
 ## Run
 
@@ -10,16 +11,18 @@ published skill.
 # structural / link / index checks (no toolchain needed)
 python3 checks/validate.py
 
-# compile-check the examples
+# execute release-specific behavior checks and compile-check the examples
 cd checks
+cargo test --test release_195_197
 python3 gen.py                                              # extract blocks -> examples/
 cargo check --examples --keep-going --message-format=json > check.json
 python3 analyze.py check.json                               # classify results
 python3 analyze.py check.json --check-baseline baseline.txt # CI gate: fail on NEW suspects
 ```
 
-Both run in CI (`.github/workflows/ci.yml`): `validate` (Python only) and
-`examples` (pinned to Rust 1.97.1, the toolchain `baseline.txt` was generated on).
+All run in CI (`.github/workflows/ci.yml`): structural validation, focused
+release-behavior tests, and the generated example gate. Rust checks are pinned
+to 1.97.1, the toolchain `baseline.txt` was generated on.
 
 ## Updating the baseline
 
@@ -44,6 +47,13 @@ skips blocks that can't compile standalone by design: `## Bad` anti-patterns,
 nightly `#![feature]` gates, procedural-macro code, placeholder crate names
 (`my_crate`, …), and bare `...` pseudocode.
 
+`tests/release_195_197.rs` executes the release-specific semantics referenced
+by the 1.95–1.97 refresh: if-let guard binding, atomic update outcomes,
+single-branch cfg selection, total ordering in `BTreeMap`, fallible integer-to-
+bool conversion, `NonZero` range iteration, and integer bit-helper zero cases.
+It also checks that mutable sequence insertion returns the inserted value for
+immediate initialization.
+
 `analyze.py` buckets each failing example by compiler error code:
 
 - **fragment** — every error is name resolution (undefined symbol/crate). These
@@ -60,4 +70,4 @@ nightly `#![feature]` gates, procedural-macro code, placeholder crate names
   generated there. Older toolchains produce spurious failures (e.g. the
   `MaybeUninit` array `From` conversions, stable since 1.95).
 - Generated files (`examples/`, `*.json`, `manifest.json`, `target/`) are
-  gitignored; only the source (`gen.py`, `analyze.py`, `Cargo.toml`) is tracked.
+  gitignored; only the harness source and focused tests are tracked.

--- a/checks/README.md
+++ b/checks/README.md
@@ -19,7 +19,7 @@ python3 analyze.py check.json --check-baseline baseline.txt # CI gate: fail on N
 ```
 
 Both run in CI (`.github/workflows/ci.yml`): `validate` (Python only) and
-`examples` (pinned to Rust 1.95.0, the toolchain `baseline.txt` was generated on).
+`examples` (pinned to Rust 1.97.1, the toolchain `baseline.txt` was generated on).
 
 ## Updating the baseline
 
@@ -29,7 +29,7 @@ it. After intentionally adding/changing examples, regenerate it on the pinned
 toolchain and review the diff:
 
 ```bash
-rustup run 1.95.0 cargo check --examples --keep-going --message-format=json > check.json
+rustup run 1.97.1 cargo check --examples --keep-going --message-format=json > check.json
 python3 analyze.py check.json --emit-baseline > baseline.txt
 ```
 
@@ -56,8 +56,8 @@ nightly `#![feature]` gates, procedural-macro code, placeholder crate names
 
 ## Notes
 
-- Run on Rust ≥ 1.95: some examples use APIs stabilized in 1.95 (e.g. the
-  `MaybeUninit` array `From` conversions) and will spuriously fail on older
-  toolchains.
+- Run on Rust ≥ 1.97: the harness is pinned to 1.97.1 and `baseline.txt` is
+  generated there. Older toolchains produce spurious failures (e.g. the
+  `MaybeUninit` array `From` conversions, stable since 1.95).
 - Generated files (`examples/`, `*.json`, `manifest.json`, `target/`) are
   gitignored; only the source (`gen.py`, `analyze.py`, `Cargo.toml`) is tracked.

--- a/checks/baseline.txt
+++ b/checks/baseline.txt
@@ -21,7 +21,7 @@ api-impl-into.md :: Implement From, Not Into :: E0119
 api-impl-into.md :: When NOT to Use impl Into :: E0562
 api-must-use.md :: When to Apply :: P:expected one of `->`, `<`,,P:missing parameters for function definition
 api-newtype-safety.md :: Constructor Patterns :: E0204
-api-newtype-safety.md :: Good :: E0063,E0308
+api-newtype-safety.md :: Good :: E0308
 api-newtype-safety.md :: Zero-Cost Abstraction :: E0308
 api-sealed-trait.md :: Full Pattern :: P:missing `fn` or `struct` for,P:non-item in item list
 api-serde-optional.md :: Multiple Optional Dependencies :: P:expected `;`, found `#`,P:expected `;`, found `borsh`,P:expected `;`, found `default`,P:expected `;`, found `rkyv`,P:expected `;`, found `serde`,P:expected one of `.`, `;`,

--- a/checks/check.sh
+++ b/checks/check.sh
@@ -4,7 +4,7 @@
 #     bash checks/check.sh
 #
 # It runs the exact same gates CI runs, pinned to the same toolchain
-# (checks/rust-toolchain.toml -> Rust 1.95.0) and the same compile target
+# (checks/rust-toolchain.toml -> Rust 1.97.1) and the same compile target
 # (x86_64-unknown-linux-gnu), so a green run here means a green run on CI.
 # On non-x86 hosts (e.g. Apple Silicon) the examples are cross-checked for that
 # target — `cargo check` type-checks without linking, so no cross-linker needed.

--- a/checks/check.sh
+++ b/checks/check.sh
@@ -17,8 +17,11 @@ echo "==> structure, links, and index parity"
 python3 "$ROOT/checks/validate.py"
 python3 "$ROOT/checks/gen_index.py" --check
 
-echo "==> generating example files from rules"
+echo "==> release-guidance behavior checks"
 cd "$ROOT/checks"
+cargo test --test release_195_197
+
+echo "==> generating example files from rules"
 python3 gen.py
 
 echo "==> compile-checking examples (target: $TARGET)"

--- a/checks/rust-toolchain.toml
+++ b/checks/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # Pins the toolchain and target for the compile-check harness so local runs
 # match CI exactly. Any `cargo` invocation in this directory uses this.
 [toolchain]
-channel = "1.95.0"
+channel = "1.97.1"
 targets = ["x86_64-unknown-linux-gnu"]

--- a/checks/tests/release_195_197.rs
+++ b/checks/tests/release_195_197.rs
@@ -1,0 +1,163 @@
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, LinkedList, VecDeque};
+use std::num::NonZeroU8;
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+
+enum Command {
+    SetPort(String),
+    Stop,
+}
+
+fn parse_port(command: Command) -> Option<u16> {
+    match command {
+        Command::SetPort(raw)
+            if let Ok(port) = raw.parse::<u16>()
+                && port != 0 =>
+        {
+            Some(port)
+        }
+        Command::SetPort(_) | Command::Stop => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct JobKey {
+    priority: u8,
+    id: u64,
+}
+
+#[test]
+fn if_let_guard_binds_only_valid_port() {
+    assert_eq!(parse_port(Command::SetPort("8080".to_owned())), Some(8080));
+    assert_eq!(parse_port(Command::SetPort("0".to_owned())), None);
+    assert_eq!(parse_port(Command::SetPort("invalid".to_owned())), None);
+    assert_eq!(parse_port(Command::Stop), None);
+}
+
+#[test]
+fn atomic_update_and_try_update_preserve_contracts() {
+    let counter = AtomicU64::new(4);
+    assert_eq!(
+        counter.update(
+            AtomicOrdering::Relaxed,
+            AtomicOrdering::Relaxed,
+            |current| current + 1
+        ),
+        4,
+    );
+    assert_eq!(counter.load(AtomicOrdering::Relaxed), 5);
+
+    assert_eq!(
+        counter.try_update(
+            AtomicOrdering::Relaxed,
+            AtomicOrdering::Relaxed,
+            |current| { (current < 6).then_some(current + 1) }
+        ),
+        Ok(5),
+    );
+    assert_eq!(
+        counter.try_update(
+            AtomicOrdering::Relaxed,
+            AtomicOrdering::Relaxed,
+            |current| { (current < 6).then_some(current + 1) }
+        ),
+        Err(6),
+    );
+}
+
+#[test]
+fn cfg_select_chooses_exactly_one_branch() {
+    let precedence = cfg_select! {
+        any(unix, windows) => "first",
+        unix => "second",
+        _ => "fallback",
+    };
+    assert_eq!(precedence, "first");
+
+    let pointer_bits = cfg_select! {
+        target_pointer_width = "64" => 64,
+        target_pointer_width = "32" => 32,
+        _ => 0,
+    };
+    assert_eq!(pointer_bits, usize::BITS);
+}
+
+#[test]
+fn derived_order_is_total_and_keeps_distinct_keys() {
+    let low = JobKey {
+        priority: 1,
+        id: 10,
+    };
+    let high_a = JobKey {
+        priority: 2,
+        id: 20,
+    };
+    let high_b = JobKey {
+        priority: 2,
+        id: 21,
+    };
+
+    assert_eq!(low.cmp(&low), Ordering::Equal);
+    assert_eq!(high_a.cmp(&high_b) == Ordering::Equal, high_a == high_b);
+    assert!(low < high_a && high_a < high_b && low < high_b);
+
+    let mut left = BTreeMap::from([(high_a, "a")]);
+    let mut right = BTreeMap::from([(high_b, "b")]);
+    left.append(&mut right);
+    assert_eq!(left.len(), 2);
+    assert!(right.is_empty());
+}
+
+#[test]
+fn fallible_bool_and_nonzero_ranges_reject_invalid_states() {
+    assert_eq!(bool::try_from(0_u8), Ok(false));
+    assert_eq!(bool::try_from(1_u8), Ok(true));
+    assert!(bool::try_from(2_u8).is_err());
+
+    let start = NonZeroU8::new(1).expect("one is non-zero");
+    let end = NonZeroU8::new(4).expect("four is non-zero");
+    let values: Vec<u8> = (start..end).map(NonZeroU8::get).collect();
+    assert_eq!(values, [1, 2, 3]);
+}
+
+#[test]
+fn integer_bit_helpers_define_zero_and_set_bit_behavior() {
+    assert_eq!(0_u32.bit_width(), 0);
+    assert_eq!(0b1110_u32.bit_width(), 4);
+    assert_eq!(0_u32.highest_one(), None);
+    assert_eq!(0b1_0100_u32.highest_one(), Some(4));
+    assert_eq!(0b1_0100_u32.lowest_one(), Some(2));
+    assert_eq!(0b1_0100_u32.isolate_highest_one(), 0b1_0000);
+    assert_eq!(0b1_0100_u32.isolate_lowest_one(), 0b100);
+}
+
+#[test]
+fn mutable_insert_returns_the_inserted_value() {
+    let mut values = Vec::new();
+    let inserted = values.push_mut(String::from("request"));
+    inserted.push_str("-ready");
+    assert_eq!(values, ["request-ready"]);
+
+    let inserted = values.insert_mut(0, String::from("first"));
+    inserted.push_str("-ready");
+    assert_eq!(values, ["first-ready", "request-ready"]);
+
+    let mut deque = VecDeque::new();
+    deque.push_back_mut(String::from("back")).push_str("-ready");
+    deque
+        .push_front_mut(String::from("front"))
+        .push_str("-ready");
+    deque
+        .insert_mut(1, String::from("middle"))
+        .push_str("-ready");
+    assert_eq!(deque, ["front-ready", "middle-ready", "back-ready"]);
+
+    let mut list = LinkedList::new();
+    list.push_back_mut(String::from("back")).push_str("-ready");
+    list.push_front_mut(String::from("front"))
+        .push_str("-ready");
+    assert_eq!(
+        list.into_iter().collect::<Vec<_>>(),
+        ["front-ready", "back-ready"]
+    );
+}

--- a/rules/conc-atomic-ordering.md
+++ b/rules/conc-atomic-ordering.md
@@ -101,6 +101,7 @@ fn test_handoff() {
 
 ## See Also
 
+- [conc-atomic-update](conc-atomic-update.md) - replace hand-written compare-exchange retry loops
 - [own-mutex-interior](own-mutex-interior.md) - prefer `Mutex<T>` when lock-free isn't required
 - [test-loom-concurrency](test-loom-concurrency.md) - exhaustively test concurrent code with loom
 - [conc-scoped-threads](conc-scoped-threads.md) - safely share stack data across threads

--- a/rules/conc-atomic-update.md
+++ b/rules/conc-atomic-update.md
@@ -1,0 +1,63 @@
+# conc-atomic-update
+
+> Use atomic `update` / `try_update` instead of hand-written compare-exchange loops
+
+## Why It Matters
+
+A compare-exchange loop must reload the value after contention, distinguish success and failure orderings, and retry without losing a concurrent update. Hand-written loops are easy to get subtly wrong. Rust 1.95 stabilized `update` and `try_update` on atomic integers, booleans, and pointers. They encode the retry loop once while leaving the state transition and memory ordering explicit.
+
+## Bad
+
+```rust
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn increment_below(counter: &AtomicU64, limit: u64) -> Result<u64, u64> {
+    let mut current = counter.load(Ordering::Acquire);
+    loop {
+        if current >= limit {
+            return Err(current);
+        }
+        match counter.compare_exchange_weak(
+            current,
+            current + 1,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(previous) => return Ok(previous),
+            Err(observed) => current = observed,
+        }
+    }
+}
+```
+
+## Good
+
+```rust
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn increment_below(counter: &AtomicU64, limit: u64) -> Result<u64, u64> {
+    counter.try_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+        (current < limit).then_some(current + 1)
+    })
+}
+
+fn toggle(flag: &std::sync::atomic::AtomicBool) -> bool {
+    flag.update(Ordering::AcqRel, Ordering::Acquire, |current| !current)
+}
+```
+
+`try_update` returns `Ok(previous)` after storing the closure result. Returning `None` stops without writing and returns `Err(current)`. `update` always produces a replacement and returns the previous value.
+
+## Key Points
+
+- The closure may run more than once under contention. It must not perform I/O, mutate unrelated state, generate IDs, or rely on being called exactly once.
+- `update` and `try_update` are compare-and-swap loops, not locks. They do not prevent ABA problems for pointer or version-like state.
+- Choose success and failure orderings exactly as for `compare_exchange`; the failure ordering may be only `Relaxed`, `Acquire`, or `SeqCst`.
+- Use `fetch_add`, `fetch_or`, and other dedicated operations when they express the transition directly. They are simpler and may map more closely to hardware.
+- Fall back to a mutex when the transition spans multiple values or requires non-trivial side effects.
+
+## See Also
+
+- [conc-atomic-ordering](conc-atomic-ordering.md) - choose the weakest correct memory ordering
+- [own-mutex-interior](own-mutex-interior.md) - use a mutex for compound state transitions
+- [test-loom-concurrency](test-loom-concurrency.md) - explore concurrent interleavings with loom

--- a/rules/conv-tryfrom-fallible.md
+++ b/rules/conv-tryfrom-fallible.md
@@ -72,6 +72,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 - Implement `TryFrom`, not `TryInto`; the blanket impl provides `TryInto` automatically (mirrors the `From`/`Into` relationship).
 - Use a concrete error type, not `String` or `Box<dyn Error>`, so callers can match on it.
 - When the conversion is truly infallible, implement `From` instead.
+- Rust 1.95 added `bool::try_from(integer)` for protocol fields where only `0` and `1` are valid. Prefer it over `value != 0`, which silently accepts malformed values such as `2`.
 
 ## See Also
 

--- a/rules/lint-cfg-check.md
+++ b/rules/lint-cfg-check.md
@@ -66,5 +66,6 @@ workspace = true
 
 - [lint-workspace-lints](lint-workspace-lints.md) - configure lints at workspace level
 - [lint-warnings-deny-config](lint-warnings-deny-config.md) - deny rustc warnings in CI via Cargo config
+- [proj-cfg-select](proj-cfg-select.md) - select one conditional item or expression in one place
 - [proj-feature-additive](proj-feature-additive.md) - design features to be strictly additive
 - [lint-warn-suspicious](lint-warn-suspicious.md) - enable suspicious lint group

--- a/rules/lint-cfg-check.md
+++ b/rules/lint-cfg-check.md
@@ -60,10 +60,11 @@ workspace = true
 
 - Feature names (`feature = "serde"`, `feature = "std"`) are registered automatically by Cargo — you do not need to list them in `check-cfg`.
 - Values in `check-cfg` entries must be quoted cfg expressions: `'cfg(name)'` or `'cfg(name, values("v1", "v2"))'`.
-- The lint fires at `warn` level; promote to `deny` in CI if you want hard failures.
+- The lint fires at `warn` level; promote to `deny` in CI, or set `[build] warnings = "deny"` (Cargo 1.97+), if you want hard failures.
 
 ## See Also
 
 - [lint-workspace-lints](lint-workspace-lints.md) - configure lints at workspace level
+- [lint-warnings-deny-config](lint-warnings-deny-config.md) - deny rustc warnings in CI via Cargo config
 - [proj-feature-additive](proj-feature-additive.md) - design features to be strictly additive
 - [lint-warn-suspicious](lint-warn-suspicious.md) - enable suspicious lint group

--- a/rules/lint-deny-correctness.md
+++ b/rules/lint-deny-correctness.md
@@ -91,13 +91,14 @@ if foo() == bar() { }  // Both return (), always true
 # Basic check
 cargo clippy
 
-# With all warnings as errors
+# With all Clippy warnings as errors
 cargo clippy -- -D warnings
 
 # Check specific lint category
 cargo clippy -- -W clippy::correctness
 
-# In CI (fail on warnings)
+# In CI: rustc warnings via Cargo 1.97+ config, Clippy still via -D
+# .cargo/config.toml → [build] warnings = "deny"
 cargo clippy -- -D warnings -D clippy::correctness
 ```
 
@@ -105,3 +106,4 @@ cargo clippy -- -D warnings -D clippy::correctness
 
 - [lint-warn-suspicious](lint-warn-suspicious.md) - Warn on suspicious code
 - [lint-warn-perf](lint-warn-perf.md) - Warn on performance issues
+- [lint-warnings-deny-config](lint-warnings-deny-config.md) - Deny rustc warnings in CI via Cargo config

--- a/rules/lint-warnings-deny-config.md
+++ b/rules/lint-warnings-deny-config.md
@@ -1,0 +1,52 @@
+# lint-warnings-deny-config
+
+> Prefer Cargo `[build] warnings = "deny"` over `RUSTFLAGS=-Dwarnings` for rustc CI
+
+## Why It Matters
+
+`RUSTFLAGS=-Dwarnings` treats rustc warnings as errors, but it also changes the compiler flag set for every crate Cargo builds. That busts the incremental and shared rustc cache, so CI and local `cargo test` rebuild more than they should. Cargo 1.97 stabilized `build.warnings`, which applies the same rustc-warning policy to local packages without rewriting `RUSTFLAGS`. Keep Clippy's `-D warnings` — `build.warnings` does not control Clippy.
+
+## Bad
+
+```bash
+# Applies to every rustc invocation and invalidates cached artifacts
+export RUSTFLAGS="-Dwarnings"
+cargo test --workspace
+```
+
+```yaml
+# .github/workflows/ci.yml
+- name: Build
+  env:
+    RUSTFLAGS: "-Dwarnings"
+  run: cargo test --workspace
+```
+
+## Good
+
+```toml
+# .cargo/config.toml — Cargo 1.97+
+[build]
+warnings = "deny"
+```
+
+```yaml
+# .github/workflows/ci.yml
+- name: Build
+  run: cargo test --workspace
+
+- name: Clippy
+  run: cargo clippy --workspace --all-targets -- -D warnings
+```
+
+## Notes
+
+- `build.warnings` accepts `"warn"` (default), `"deny"`, and `"allow"`. Use `"deny"` in CI so new rustc warnings fail the build.
+- The setting is documented in the Cargo Book as `build.warnings`. It covers rustc lints from your packages; it is not a substitute for `cargo clippy -- -D warnings`.
+- Prefer a checked-in `.cargo/config.toml` (or a CI `--config 'build.warnings="deny"'` override) over a global `RUSTFLAGS` export.
+
+## See Also
+
+- [lint-workspace-lints](lint-workspace-lints.md) - configure rustc and Clippy lints in Cargo.toml
+- [lint-deny-correctness](lint-deny-correctness.md) - deny Clippy correctness lints
+- [lint-cfg-check](lint-cfg-check.md) - catch cfg typos before they become silent dead code

--- a/rules/lint-workspace-lints.md
+++ b/rules/lint-workspace-lints.md
@@ -140,10 +140,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      
+      - name: Rustc
+        # Cargo 1.97+: [build] warnings = "deny" in .cargo/config.toml
+        run: cargo check --workspace --all-targets
+
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
-      
+
       - name: Rustdoc
         run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 ```
@@ -168,5 +171,6 @@ missing_errors_doc = "allow"  # Override pedantic
 ## See Also
 
 - [lint-deny-correctness](./lint-deny-correctness.md) - Critical lints
+- [lint-warnings-deny-config](./lint-warnings-deny-config.md) - rustc warnings in CI via Cargo config
 - [proj-workspace-deps](./proj-workspace-deps.md) - Workspace configuration
 - [anti-unwrap-abuse](./anti-unwrap-abuse.md) - unwrap lints

--- a/rules/mem-assert-type-size.md
+++ b/rules/mem-assert-type-size.md
@@ -154,6 +154,15 @@ struct AppConfig { /* many fields */ }
 // Size doesn't matter, only one instance
 ```
 
+## Do Not Freeze Rust Enum Layout by Accident
+
+Rust may change the layout of an enum that has no representation guarantee; a
+Rust 1.97 compiler change did so for some valid enums. A passing size assertion
+does not make the layout stable. Use `#[repr(C)]` or an explicit integer
+representation only when an FFI or wire contract requires it, assert the
+discriminants and offsets that contract depends on, and serialize logical
+fields rather than raw Rust memory.
+
 ## Cargo.toml
 
 ```toml

--- a/rules/num-bit-width.md
+++ b/rules/num-bit-width.md
@@ -1,0 +1,96 @@
+# num-bit-width
+
+> Use integer `bit_width` / `highest_one` / `isolate_*_one` instead of hand-rolled bit math
+
+## Why It Matters
+
+Counting bits with `leading_zeros` and isolating a set bit with `n & n.wrapping_neg()` are easy to get slightly wrong — especially at zero, where `leading_zeros` is the full width and a mask must not invent a bit. Rust 1.97 added named methods on every integer primitive (and `NonZero`) that return the bit width, the index of the highest or lowest set bit, or a value with only that bit kept. The standard library documents the zero cases; call the method instead of re-deriving it.
+
+## Bad
+
+```rust
+fn needed_bits(n: u32) -> u32 {
+    if n == 0 {
+        0
+    } else {
+        32 - n.leading_zeros()  // width minus leading zeros; wrong the moment you forget the n == 0 arm
+    }
+}
+
+fn highest_set_bit(n: u32) -> Option<u32> {
+    if n == 0 {
+        None
+    } else {
+        Some(31 - n.leading_zeros())  // 31 is width-1 — off-by-one bait
+    }
+}
+
+fn lowest_power_of_two(n: u32) -> u32 {
+    n & n.wrapping_neg()  // classic lowest-set-bit mask; yields 0 for 0 by accident, not by contract
+}
+```
+
+## Good
+
+```rust
+fn needed_bits(n: u32) -> u32 {
+    n.bit_width()  // 0 for 0, documented — no manual zero arm
+}
+
+fn highest_set_bit(n: u32) -> Option<u32> {
+    n.highest_one()  // Option: the zero case is in the type
+}
+
+fn lowest_set_bit(n: u32) -> Option<u32> {
+    n.lowest_one()
+}
+
+fn lowest_power_of_two(n: u32) -> u32 {
+    n.isolate_lowest_one()  // 0 for 0, by contract
+}
+
+fn highest_power_of_two(n: u32) -> u32 {
+    n.isolate_highest_one()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bit_width_is_zero_for_zero() {
+        assert_eq!(needed_bits(0), 0);
+        assert_eq!(needed_bits(0b111), 3);
+        assert_eq!(needed_bits(0b1110), 4);
+    }
+
+    #[test]
+    fn highest_one_is_none_for_zero() {
+        assert_eq!(highest_set_bit(0), None);
+        assert_eq!(highest_set_bit(0b1_0000), Some(4));
+        assert_eq!(lowest_set_bit(0b1_0000), Some(4));
+        assert_eq!(lowest_set_bit(0b1_1111), Some(0));
+    }
+
+    #[test]
+    fn isolate_keeps_a_single_bit() {
+        let n = 0b_01100100u32;
+        assert_eq!(lowest_power_of_two(n), 0b_00000100);
+        assert_eq!(highest_power_of_two(n), 0b_01000000);
+        assert_eq!(lowest_power_of_two(0), 0);
+    }
+}
+```
+
+## Key Points
+
+- `bit_width` is the minimum number of bits needed to represent the value, and is `0` when the value is `0`.
+- `highest_one` / `lowest_one` return `Option<u32>` indexes (or a bare `u32` on `NonZero`, where zero is impossible).
+- `isolate_highest_one` / `isolate_lowest_one` return a value with only that bit set, or `0` when the input is `0`.
+- Prefer these over `32 - leading_zeros()` or `n & n.wrapping_neg()` even when the hand-rolled form is correct — the named methods make the zero case obvious to the next reader.
+
+## See Also
+
+- [num-overflow-explicit](num-overflow-explicit.md) - name overflow intent with `checked_`/`saturating_`/`wrapping_`
+- [num-cast-try-from](num-cast-try-from.md) - avoid `as` for narrowing integer conversions
+- [mem-smaller-integers](mem-smaller-integers.md) - pick the smallest integer type that fits

--- a/rules/num-float-compare.md
+++ b/rules/num-float-compare.md
@@ -89,3 +89,4 @@ mod tests {
 ## See Also
 
 - [num-overflow-explicit](num-overflow-explicit.md) - handle integer overflow explicitly
+- [trait-ord-consistent](trait-ord-consistent.md) - keep ordered collection keys on one total order

--- a/rules/num-nonzero.md
+++ b/rules/num-nonzero.md
@@ -86,6 +86,7 @@ mod tests {
 - **Construction**: `NonZeroU32::new(n) -> Option<NonZeroU32>`. Use `NonZeroU32::new(n).expect("n must be non-zero")` only at well-verified program boundaries, not in production fallible paths.
 - **Access**: `.get()` returns the inner primitive value.
 - **Arithmetic**: `NonZeroU32` does not implement `Add`/`Sub` directly (the result could be zero). Extract with `.get()`, do arithmetic, and reconstruct with `NonZeroU32::new(result)?`.
+- **Ranges**: Rust 1.96 added iteration for ranges of `NonZero*` integers. Keep bounds non-zero instead of extracting primitives merely to iterate.
 - **Niche optimization** applies to `Option` and `Result`: the compiler stores the `None`/`Err` discriminant in the zero bit-pattern, so no extra word is needed. This also applies to custom newtypes that wrap `NonZero*`.
 
 ## See Also

--- a/rules/num-nonzero.md
+++ b/rules/num-nonzero.md
@@ -92,3 +92,4 @@ mod tests {
 
 - [type-newtype-ids](type-newtype-ids.md) - wrap IDs in newtypes for type-safe distinctions
 - [mem-smaller-integers](mem-smaller-integers.md) - use the smallest integer type that fits
+- [num-bit-width](num-bit-width.md) - use the named bit-width and set-bit methods instead of hand-rolled masks

--- a/rules/opt-inline-never-cold.md
+++ b/rules/opt-inline-never-cold.md
@@ -114,7 +114,7 @@ fn read_config(path: &Path) -> Result<Config, MyError> {
 ## likely/unlikely Hints
 
 ```rust
-// Nightly: std::hint likely/unlikely branch hints (still unstable as of Rust 1.96)
+// Nightly: std::hint likely/unlikely branch hints (still unstable as of Rust 1.97)
 // (std::hint::cold_path() is stable since 1.95 for marking the rare branch)
 #![feature(likely_unlikely)]
 use std::hint::{likely, unlikely};

--- a/rules/opt-likely-hint.md
+++ b/rules/opt-likely-hint.md
@@ -50,7 +50,7 @@ fn cold_empty_error() -> Result<(), Error> {
 ## Nightly: std::hint
 
 ```rust
-// Requires nightly; still unstable as of Rust 1.96
+// Requires nightly; still unstable as of Rust 1.97
 #![feature(likely_unlikely)]
 use std::hint::{likely, unlikely};
 
@@ -70,7 +70,7 @@ fn process(data: &Data) -> i32 {
 ## Boolean Likely Wrapper (Nightly)
 
 ```rust
-// Requires nightly; still unstable as of Rust 1.96
+// Requires nightly; still unstable as of Rust 1.97
 #![feature(likely_unlikely)]
 
 #[inline(always)]

--- a/rules/pat-if-let-chains.md
+++ b/rules/pat-if-let-chains.md
@@ -77,5 +77,6 @@ Use `let ... else` when the goal is early return on failure; use if-let chains w
 
 ## See Also
 
+- [pat-if-let-guards](pat-if-let-guards.md) - bind data needed only by one match arm
 - [pat-let-else](pat-let-else.md) - early-return pattern extraction without nesting
 - [pat-matches-macro](pat-matches-macro.md) - boolean pattern tests with `matches!()`

--- a/rules/pat-if-let-guards.md
+++ b/rules/pat-if-let-guards.md
@@ -1,0 +1,62 @@
+# pat-if-let-guards
+
+> Use `if let` match guards to bind data needed only by one arm
+
+## Why It Matters
+
+A boolean match guard can test a condition, but it cannot bind the successful value of a fallible operation for the arm body. That often leads to duplicated parsing, a nested `match`, or an `unwrap()` after an `is_ok()` check. Rust 1.95 stabilized `if let` guards: the guard can destructure a value and keep its bindings in scope for the selected arm. Use them when a pattern identifies the candidate and one additional fallible match decides whether the arm applies.
+
+## Bad
+
+```rust
+enum Command {
+    SetPort(String),
+    Stop,
+}
+
+fn apply(command: Command) -> Option<u16> {
+    match command {
+        Command::SetPort(raw) if raw.parse::<u16>().is_ok() => {
+            // Parses twice and relies on the guard staying in sync.
+            Some(raw.parse::<u16>().unwrap())
+        }
+        Command::SetPort(_) | Command::Stop => None,
+    }
+}
+```
+
+## Good
+
+```rust
+enum Command {
+    SetPort(String),
+    Stop,
+}
+
+fn apply(command: Command) -> Option<u16> {
+    match command {
+        Command::SetPort(raw)
+            if let Ok(port) = raw.parse::<u16>()
+                && port != 0 =>
+        {
+            Some(port)
+        }
+        Command::SetPort(_) | Command::Stop => None,
+    }
+}
+```
+
+The `port` binding exists only in the guarded arm. If parsing fails or the following condition is false, matching continues with the next arm.
+
+## Key Points
+
+- Use an `if let` guard when the extra binding belongs to one match arm; use an if-let chain when the whole operation is naturally an `if` expression.
+- Guard expressions may run while the matched value is only conditionally selected. Keep them free of externally visible side effects.
+- Preserve a fallback arm: a guarded pattern does not make the unguarded cases exhaustive.
+- Prefer a nested `match` when different failure variants need different behavior rather than collapsing them into a guard miss.
+
+## See Also
+
+- [pat-if-let-chains](pat-if-let-chains.md) - combine bindings and boolean conditions in an `if` header
+- [pat-exhaustive-enum](pat-exhaustive-enum.md) - handle every enum variant explicitly
+- [pat-let-else](pat-let-else.md) - extract a pattern and return early on failure

--- a/rules/perf-entry-api.md
+++ b/rules/perf-entry-api.md
@@ -119,6 +119,29 @@ match map.entry(key) {
 }
 ```
 
+## Mutate Newly Inserted Sequence Values
+
+Rust 1.95 added mutable-returning insertion methods across sequential
+collections: `Vec::{push_mut, insert_mut}`,
+`VecDeque::{push_back_mut, push_front_mut, insert_mut}`, and
+`LinkedList::{push_back_mut, push_front_mut}`. Use them when insertion is
+immediately followed by mutation; they return the inserted element directly,
+without a second index or end lookup:
+
+```rust
+#[derive(Default)]
+struct Request {
+    headers: Vec<(String, String)>,
+}
+
+let mut queue = Vec::new();
+let request = queue.push_mut(Request::default());
+request.headers.push(("accept".to_owned(), "application/json".to_owned()));
+```
+
+Use ordinary `push` when no mutable reference is needed. The new methods
+clarify the ownership flow; they do not make insertion itself free.
+
 ## Performance
 
 | Pattern | Lookups | Hash Computations |

--- a/rules/proj-cfg-select.md
+++ b/rules/proj-cfg-select.md
@@ -1,0 +1,67 @@
+# proj-cfg-select
+
+> Use `cfg_select!` for one-of-many conditional items or expressions
+
+## Why It Matters
+
+Repeated `#[cfg(...)]` attributes make mutually exclusive platform branches hard to audit. Two predicates can overlap and define an item twice, or leave a supported target with no definition. Rust 1.95 stabilized `cfg_select!`, which evaluates branches in order and keeps only the first match. A visible `_` fallback makes the coverage decision explicit in one place.
+
+## Bad
+
+```rust
+#[cfg(unix)]
+fn path_separator() -> char {
+    '/'
+}
+
+#[cfg(windows)]
+fn path_separator() -> char {
+    '\\'
+}
+
+// A new target needs another detached definition. Overlapping custom cfgs can
+// also select two definitions and fail far from this code.
+```
+
+## Good
+
+```rust
+cfg_select! {
+    unix => {
+        fn path_separator() -> char {
+            '/'
+        }
+    }
+    windows => {
+        fn path_separator() -> char {
+            '\\'
+        }
+    }
+    _ => {
+        compile_error!("unsupported path platform");
+    }
+}
+
+fn native_label() -> &'static str {
+    cfg_select! {
+        target_os = "linux" => "linux",
+        target_os = "macos" => "macos",
+        target_os = "windows" => "windows",
+        _ => "other",
+    }
+}
+```
+
+## Key Points
+
+- Branches are tested in source order; the first matching branch wins. Order overlapping predicates from most specific to least specific.
+- Use `_` for an intentional fallback. Prefer `compile_error!` when an unsupported target must fail closed.
+- `cfg_select!` works in item and expression position and is available from the prelude.
+- Keep `check-cfg` declarations for custom cfg names. Selection does not validate spelling or allowed values.
+- Use ordinary `#[cfg]` for one independent item; use `cfg_select!` when the branches represent one choice.
+
+## See Also
+
+- [lint-cfg-check](./lint-cfg-check.md) - declare custom cfg names and reject typos
+- [proj-feature-additive](./proj-feature-additive.md) - keep Cargo features additive rather than mutually exclusive
+- [proj-mod-by-feature](./proj-mod-by-feature.md) - organize feature-specific implementation code coherently

--- a/rules/proj-pub-crate-internal.md
+++ b/rules/proj-pub-crate-internal.md
@@ -132,6 +132,20 @@ pub use service::UserService;  // Only export the public API
 | `pub(crate)` internals | Only `pub` items matter | Can refactor freely |
 | Private | Maximum encapsulation | Limits crate flexibility |
 
+## Catch Accidental `pub` in Binaries
+
+Rust 1.97 added the allow-by-default `dead_code_pub_in_binary` lint. Binary
+crates can enable it to catch `pub` items that are unused within the binary and
+therefore do not form a reachable library API:
+
+```rust
+#![warn(dead_code_pub_in_binary)]
+```
+
+Treat a warning as a prompt to narrow visibility, not to add a dummy use.
+Library crates need API-aware tooling instead: downstream users may rely on a
+public item even when the defining crate does not.
+
 ## See Also
 
 - [proj-pub-super-parent](./proj-pub-super-parent.md) - Parent-only visibility

--- a/rules/proj-workspace-deps.md
+++ b/rules/proj-workspace-deps.md
@@ -126,6 +126,26 @@ serde = { workspace = true, optional = true }
 serde = ["dep:serde"]
 ```
 
+## Publishable Git Dependencies
+
+Cargo 1.96 lets a dependency name both a git source for local development and
+an alternate registry source for publication:
+
+```toml
+[dependencies]
+shared-types = { git = "https://github.com/acme/shared-types", rev = "8e4d7ab", version = "2.3", registry = "company" }
+```
+
+Cargo uses the pinned git revision locally and records the registry dependency
+when packaging. Keep `version` compatible with the pinned revision, and run
+`cargo package` plus tests against the packaged artifact in CI; otherwise local
+and published consumers can compile different code under the same dependency
+declaration.
+
+This form is for packages published to the named alternate registry. Crates.io
+does not accept dependencies that resolve from another registry; use a
+crates.io version source there, or do not publish that package to crates.io.
+
 ## Complete Workspace Example
 
 ```toml

--- a/rules/proj-workspace-large.md
+++ b/rules/proj-workspace-large.md
@@ -155,6 +155,22 @@ my-app-core = { path = "../core" }
 my-app-common = { path = "../common" }
 ```
 
+## Read-Only Source Trees
+
+Cargo 1.97 added `resolver.lockfile-path` for environments where the source
+checkout is read-only but dependency resolution may update the lockfile:
+
+```toml
+# supplied as CI-local Cargo configuration, not committed as a developer path
+[resolver]
+lockfile-path = "/workspace-state/Cargo.lock"
+```
+
+Keep the ordinary workspace `Cargo.lock` checked in for reproducible
+application builds. Override its location only for a deliberate sandbox,
+packaging, or read-only-source workflow, and preserve the resulting lockfile as
+an input or artifact rather than resolving from scratch on every run.
+
 ## See Also
 
 - [proj-workspace-deps](./proj-workspace-deps.md) - Workspace dependencies

--- a/rules/trait-ord-consistent.md
+++ b/rules/trait-ord-consistent.md
@@ -1,0 +1,104 @@
+# trait-ord-consistent
+
+> Keep `Ord`, `PartialOrd`, `Eq`, and `PartialEq` consistent
+
+## Why It Matters
+
+Ordered collections assume that comparison defines one total order. If `a.cmp(&b) == Ordering::Equal` disagrees with `a == b`, a `BTreeMap` can lose entries, return the wrong value, or panic after an internal optimization changes. Rust 1.96 optimized `BTreeMap::append`, exposing more incorrect `Ord` implementations; the implementation was already a logic error. Derive the comparison traits together whenever field order expresses the intended key.
+
+## Bad
+
+```rust
+use std::cmp::Ordering;
+
+#[derive(Debug)]
+struct Job {
+    id: u64,
+    priority: u8,
+}
+
+impl PartialEq for Job {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+impl Eq for Job {}
+
+impl Ord for Job {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.priority.cmp(&other.priority)
+    }
+}
+impl PartialOrd for Job {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+// Same priority compares Equal even when the IDs — and Eq — differ.
+```
+
+## Good
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct JobKey {
+    priority: u8,
+    id: u64,
+}
+
+#[derive(Debug)]
+struct Job {
+    key: JobKey,
+    payload: String,
+}
+```
+
+If comparison must be manual, implement every relation from the same key:
+
+```rust
+use std::cmp::Ordering;
+
+#[derive(Debug)]
+struct JobKey {
+    id: u64,
+    priority: u8,
+}
+
+impl JobKey {
+    fn order_key(&self) -> (u8, u64) {
+        (self.priority, self.id)
+    }
+}
+
+impl PartialEq for JobKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.order_key() == other.order_key()
+    }
+}
+impl Eq for JobKey {}
+
+impl Ord for JobKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.order_key().cmp(&other.order_key())
+    }
+}
+impl PartialOrd for JobKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+```
+
+## Key Points
+
+- For every `a` and `b`, `a.cmp(&b) == Ordering::Equal` must be equivalent to `a == b`.
+- The order must be reflexive, antisymmetric, and transitive. Test these properties for manual implementations.
+- Do not implement `Ord` for domains with a genuine partial order. Floating-point values require an explicit policy such as `total_cmp` or a validated non-NaN wrapper.
+- Keep mutable payload outside the ordered key. Mutating a key while it is inside an ordered collection violates the collection's invariants.
+
+## See Also
+
+- [type-newtype-ids](type-newtype-ids.md) - give identifiers a dedicated key type
+- [num-float-compare](num-float-compare.md) - use `total_cmp` when floats need a total order
+- [trait-default-methods](trait-default-methods.md) - preserve trait contracts when overriding behavior

--- a/rules/unsafe-extern-block.md
+++ b/rules/unsafe-extern-block.md
@@ -64,6 +64,7 @@ Run `cargo fix --edition` to apply the mechanical part of this migration automat
 - The `unsafe` on the block means "I assert these declarations faithfully describe the external ABI". It does not make calls to the items safe by itself.
 - Marking an item `safe` is a promise: if that item is actually unsafe to call, adding `safe` is itself unsound — the compiler will not catch a wrong annotation.
 - `bindgen` (0.70+) and `cbindgen` have been updated to emit `unsafe extern` blocks for Rust 2024 output. Update your code generator if you use one.
+- Use `std::ffi::c_*` types for C ABI declarations instead of assuming a Rust primitive has the same width. Rust 1.96 changed `c_double` to `f32` on AVR to match that platform's C ABI; a hard-coded `f64` declaration is wrong there.
 - The `extern "Rust"` ABI for cross-crate `#[no_mangle]` functions follows the same rules (see `unsafe-no-mangle-unsafe`).
 
 ## See Also

--- a/rules/unsafe-no-mangle-unsafe.md
+++ b/rules/unsafe-no-mangle-unsafe.md
@@ -62,7 +62,9 @@ Run `cargo fix --edition` when migrating to the 2024 edition — it rewrites bar
 - Symbol collisions are especially dangerous in plugin architectures, `cdylib` crates, embedded firmware with custom linker scripts, and any codebase that links multiple Rust crates into a single binary.
 - These attributes interact with `unsafe extern` blocks (see `unsafe-extern-block`): external symbols you import and symbols you export follow the same 2024-edition safety rules.
 - The bare forms (`#[no_mangle]` without `unsafe`) are a hard error in Rust 2024 edition code. They still compile in earlier editions but emit a deprecation warning with `--warn future-incompatible`.
+- Rust 1.96 made the first duplicate `export_name`, `link_name`, or `link_section` attribute take precedence. Never stack duplicate symbol attributes; keep one audited source of truth.
 - `link_section` values are validated in Rust 1.97: a bare ELF name like `.init_array` is an error on Mach-O. Use a `cfg_attr` per target, or a name your linker script actually defines.
+- Rust 1.97 also rejects empty `export_name` values and validates `link_name` / `link` parameters. Treat those diagnostics as contract defects, not warnings to suppress.
 
 ## See Also
 

--- a/rules/unsafe-no-mangle-unsafe.md
+++ b/rules/unsafe-no-mangle-unsafe.md
@@ -38,7 +38,11 @@ pub fn plugin_main() {
     // ...
 }
 
-#[unsafe(link_section = ".init_array")]
+// Section names are platform-specific: ELF takes ".init_array", Mach-O
+// takes a "segment,section" pair. Rust 1.97 rejects an invalid specifier
+// instead of ignoring it.
+#[cfg_attr(target_os = "macos", unsafe(link_section = "__DATA,__mod_init_func"))]
+#[cfg_attr(not(target_os = "macos"), unsafe(link_section = ".init_array"))]
 static INIT: extern "C" fn() = init;
 ```
 
@@ -58,6 +62,7 @@ Run `cargo fix --edition` when migrating to the 2024 edition — it rewrites bar
 - Symbol collisions are especially dangerous in plugin architectures, `cdylib` crates, embedded firmware with custom linker scripts, and any codebase that links multiple Rust crates into a single binary.
 - These attributes interact with `unsafe extern` blocks (see `unsafe-extern-block`): external symbols you import and symbols you export follow the same 2024-edition safety rules.
 - The bare forms (`#[no_mangle]` without `unsafe`) are a hard error in Rust 2024 edition code. They still compile in earlier editions but emit a deprecation warning with `--warn future-incompatible`.
+- `link_section` values are validated in Rust 1.97: a bare ELF name like `.init_array` is an error on Mach-O. Use a `cfg_attr` per target, or a name your linker script actually defines.
 
 ## See Also
 


### PR DESCRIPTION
Audits the complete Rust 1.95, 1.96, and 1.97 release-note sets and refreshes the corpus for Rust 1.97.1. This supersedes the earlier pass that classified 1.97 while inheriting the existing 1.95/1.96 coverage.

## New rules

- `pat-if-let-guards` — bind fallible data needed only by one match arm (Rust 1.95)
- `conc-atomic-update` — replace hand-written compare-exchange loops with `update` / `try_update` (Rust 1.95)
- `proj-cfg-select` — express one-of-many conditional items/expressions with ordered `cfg_select!` branches (Rust 1.95)
- `trait-ord-consistent` — preserve the `Ord`/`Eq` contract relied on by ordered collections; includes the Rust 1.96 `BTreeMap::append` compatibility lesson
- `lint-warnings-deny-config` — prefer Cargo 1.97 `[build] warnings = "deny"` over cache-busting global `RUSTFLAGS=-Dwarnings`
- `num-bit-width` — use Rust 1.97 `bit_width` / `highest_one` / `lowest_one` / `isolate_*_one`

## Existing-rule updates

### Rust 1.95

- Preserve and cross-check existing `MaybeUninit` array-conversion and `cold_path` guidance.
- Add `bool::try_from(integer)` for strict 0/1 protocol fields.
- Add the exact mutable-insertion API matrix for `Vec`, `VecDeque`, and `LinkedList`.

### Rust 1.96

- Preserve and cross-check existing `assert_matches!` guidance.
- Add `NonZero` range iteration, publishable git + alternate-registry dependencies (with the crates.io restriction), enum-layout compatibility guidance, AVR `c_double` ABI guidance, and duplicate symbol-attribute precedence.

### Rust 1.97

- Add `dead_code_pub_in_binary`, `resolver.lockfile-path` for deliberate read-only-source workflows, Cargo warning policy, integer bit helpers, Mach-O `link_section` validation, and stricter `export_name` / `link_name` validation guidance.
- Pin CI, compile checks, documentation, and the baseline to Rust 1.97.1.
- Regenerate the rule index: 265 → 271 rules across 26 categories.

Every release-note entry was evaluated as a new rule, an existing-rule update, or a skip. Compiler-enforced diagnostics, target promotions/features, internal implementation changes, convenience-only trait impls/shorthands, and platform changes with no portable authoring decision were intentionally not turned into rules.

## Executable checks

`checks/tests/release_195_197.rs` is now part of `checks/check.sh` and CI. Seven focused tests execute:

- if-let guard binding and fallthrough
- atomic `update` / `try_update` outcomes
- overlapping `cfg_select!` first-match precedence
- `Ord`/`Eq` consistency through `BTreeMap::append`
- `bool::try_from` rejection and `NonZero` ranges
- integer bit-helper zero/set-bit behavior
- the full mutable-insertion method matrix for `Vec`, `VecDeque`, and `LinkedList`

The existing extraction gate additionally generated and checked 831 examples from 1,144 Rust blocks. Baseline gate: 124 known suspects, zero new suspects.

## Verification and review

- `python3 checks/validate.py` — 271 rules valid; all indexed
- `python3 checks/gen_index.py --check` — 271 rules / 26 categories, current
- `cargo test --test release_195_197` — 7 passed
- `python3 checks/analyze.py ... --check-baseline` — no new compile suspects
- full `bash checks/check.sh` — passed on Rust 1.97.1
- independent OpenAI Codex review — two rounds of blockers fixed (alternate-registry/crates.io constraint, `cfg_select!` precedence coverage, exact mutable-insertion API matrix); terminal PASS

`[Unreleased]` is deliberate: parallel upstream PRs must not both assign the next release version.